### PR TITLE
항공권 관련 Controller의 반환 타입을 ResponseEntity로 적용하고 예외 핸들링 코드를 추가

### DIFF
--- a/src/main/java/com/grepp/carrierroute/booking/controller/FlightBookingController.java
+++ b/src/main/java/com/grepp/carrierroute/booking/controller/FlightBookingController.java
@@ -2,6 +2,8 @@ package com.grepp.carrierroute.booking.controller;
 
 import com.grepp.carrierroute.booking.dto.*;
 import com.grepp.carrierroute.booking.service.FlightBookingService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -16,23 +18,23 @@ public class FlightBookingController {
     }
 
     @PostMapping("/bookings/flights")
-    public FlightBookingResponseDto bookFlight(@CookieValue(value = "userId") String userId, @RequestBody FlightBookingRequestDto flightBookingRequestDto){
-        return flightBookingService.bookFlight(userId, flightBookingRequestDto);
+    public ResponseEntity<FlightBookingResponseDto> bookFlight(@CookieValue(value = "userId") String userId, @RequestBody FlightBookingRequestDto flightBookingRequestDto){
+        return new ResponseEntity<>(flightBookingService.bookFlight(userId, flightBookingRequestDto), HttpStatus.CREATED);
     }
 
 
     @GetMapping("/bookings/flights/{bookingId}")
-    public BookedFlightResponseDto getBookedFlight(@PathVariable Long bookingId){
-        return flightBookingService.getBookedFlight(bookingId);
+    public ResponseEntity<BookedFlightResponseDto> getBookedFlight(@PathVariable Long bookingId){
+        return new ResponseEntity<>(flightBookingService.getBookedFlight(bookingId), HttpStatus.OK);
     }
 
     @GetMapping("/bookings/flights")
-    public List<BookedFlightResponseDto> getBookedFlights(@CookieValue(value = "userId") String userId){
-        return flightBookingService.getBookedFlights(userId);
+    public ResponseEntity<List<BookedFlightResponseDto>> getBookedFlights(@CookieValue(value = "userId") String userId){
+        return new ResponseEntity<>(flightBookingService.getBookedFlights(userId), HttpStatus.OK);
     }
 
     @DeleteMapping("/bookings/flights/{bookingId}")
-    public CancelBookedFlightDto cancelBookedFlight(@CookieValue(value = "userId") String userId, @PathVariable Long bookingId){
-        return flightBookingService.cancelBookedFlight(userId, bookingId);
+    public ResponseEntity<CancelBookedFlightDto> cancelBookedFlight(@CookieValue(value = "userId") String userId, @PathVariable Long bookingId){
+        return new ResponseEntity<>(flightBookingService.cancelBookedFlight(userId, bookingId), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/grepp/carrierroute/booking/service/FlightBookingService.java
+++ b/src/main/java/com/grepp/carrierroute/booking/service/FlightBookingService.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -94,7 +93,7 @@ public class FlightBookingService {
         User user = getUser(userId);
         Flight canceledFlight = findBookedFlightById(bookingId);
 
-        if (!isValidCancel(canceledFlight)) {
+        if (isNotValidCancel(canceledFlight)) {
             throw new CancellationNotAllowedException(Flight.class, bookingId);
         }
 
@@ -138,8 +137,8 @@ public class FlightBookingService {
 
     }
 
-    private boolean isValidCancel(Flight canceledFlight) {
-        return canceledFlight.getAirplaneSeat()
+    private boolean isNotValidCancel(Flight canceledFlight) {
+        return !canceledFlight.getAirplaneSeat()
                 .getAirplane()
                 .getAirline()
                 .isCancellationAllowed();

--- a/src/main/java/com/grepp/carrierroute/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/grepp/carrierroute/exception/GlobalExceptionHandler.java
@@ -13,8 +13,12 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 @Slf4j
@@ -74,5 +78,17 @@ public class GlobalExceptionHandler {
 
     private void putError(ObjectError error, Map<String, String> errors) {
         errors.put(((FieldError) error).getField(), error.getDefaultMessage());
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<List<String>> constraintViolationException(ConstraintViolationException e) {
+        return new ResponseEntity<>(extractErrorMessages(e),HttpStatus.BAD_REQUEST);
+    }
+
+    private List<String> extractErrorMessages(ConstraintViolationException e) {
+        return e.getConstraintViolations()
+                .stream()
+                .map(ConstraintViolation::getMessage)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/grepp/carrierroute/flight/controller/FlightController.java
+++ b/src/main/java/com/grepp/carrierroute/flight/controller/FlightController.java
@@ -2,6 +2,8 @@ package com.grepp.carrierroute.flight.controller;
 
 import com.grepp.carrierroute.flight.dto.*;
 import com.grepp.carrierroute.flight.service.FlightService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -13,12 +15,12 @@ public class FlightController {
     }
 
     @GetMapping("/flights")
-    public FlightsSearchResponseDto getFlights(@RequestParam("searchTypeName") SearchType searchType, @RequestBody FlightSearchRequestDto flightSearchRequestDto){
-        return flightService.getFlights(searchType,flightSearchRequestDto);
+    public ResponseEntity<FlightsSearchResponseDto> getFlights(@RequestParam("searchTypeName") SearchType searchType, @RequestBody FlightSearchRequestDto flightSearchRequestDto){
+        return new ResponseEntity<>(flightService.getFlights(searchType,flightSearchRequestDto), HttpStatus.OK);
     }
 
     @GetMapping("/flights/{flightId}")
-    public FlightSearchResponseDto getFlight(@PathVariable Long flightId){
-        return flightService.getFlight(flightId);
+    public ResponseEntity<FlightSearchResponseDto> getFlight(@PathVariable Long flightId){
+        return new ResponseEntity<>(flightService.getFlight(flightId), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/grepp/carrierroute/flight/domain/Airline.java
+++ b/src/main/java/com/grepp/carrierroute/flight/domain/Airline.java
@@ -2,9 +2,13 @@ package com.grepp.carrierroute.flight.domain;
 
 import com.grepp.carrierroute.common.BaseTimeEntity;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 
 @Entity
 @Table(name = "airline")
@@ -15,14 +19,24 @@ public class Airline extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
+    @NotNull(message = "항공사 이름은 존재해야 합니다.")
     @Column(name = "name", nullable = false)
     private String name;
 
     @Column(name = "is_cancellation_allowed", nullable = false)
     private boolean isCancellationAllowed;
 
+    @Max(value = 100, message = "환불 퍼센트는 100이하 이어야 합니다.")
+    @Min(value = 0, message = "환불 퍼센트는 0이상 이어야 합니다.")
     @Column(name = "refund_percentage", nullable = false)
     private int refundPercentage;
+
+    @Builder
+    public Airline(String name, boolean isCancellationAllowed, int refundPercentage){
+        this.name = name;
+        this.isCancellationAllowed = isCancellationAllowed;
+        this.refundPercentage = refundPercentage;
+    }
 
     // getter
     public Long getId() {

--- a/src/main/java/com/grepp/carrierroute/flight/domain/Airline.java
+++ b/src/main/java/com/grepp/carrierroute/flight/domain/Airline.java
@@ -21,7 +21,7 @@ public class Airline extends BaseTimeEntity {
     @Column(name = "is_cancellation_allowed", nullable = false)
     private boolean isCancellationAllowed;
 
-    @Column(name = "refund_policy", nullable = false)
+    @Column(name = "refund_percentage", nullable = false)
     private int refundPercentage;
 
     // getter

--- a/src/main/java/com/grepp/carrierroute/flight/domain/Airplane.java
+++ b/src/main/java/com/grepp/carrierroute/flight/domain/Airplane.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 
 @Table(name = "airplane")
 @Entity
@@ -18,6 +19,7 @@ public class Airplane {
     @JoinColumn(name = "airline_id", referencedColumnName = "id")
     private Airline airline;
 
+    @NotNull(message = "비행기 이름은 존재해야 합니다.")
     @Column(name = "name", nullable = false)
     private String name;
 

--- a/src/main/java/com/grepp/carrierroute/flight/domain/AirplaneSeat.java
+++ b/src/main/java/com/grepp/carrierroute/flight/domain/AirplaneSeat.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.Positive;
 
 @Table(name = "airplane_seat")
 @Entity
@@ -15,12 +16,13 @@ public class AirplaneSeat {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "airplane_ID", referencedColumnName = "id")
+    @JoinColumn(name = "airplane_id", referencedColumnName = "id")
     private Airplane airplane;
 
     @Column(name = "cabin_class", nullable = false)
     private CabinClass cabinClass;
 
+    @Positive(message = "좌석번호는 양수이어야 합니다.")
     @Column(name = "seat_num", nullable = false)
     private int seatNum;
 

--- a/src/main/java/com/grepp/carrierroute/flight/domain/Flight.java
+++ b/src/main/java/com/grepp/carrierroute/flight/domain/Flight.java
@@ -9,6 +9,7 @@ import lombok.NonNull;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
 import java.time.LocalDateTime;
 
 @Entity
@@ -28,27 +29,32 @@ public class Flight extends BaseTimeEntity {
     @JoinColumn(name = "airplane_seat_id", referencedColumnName = "id")
     private AirplaneSeat airplaneSeat;
 
+    @NotNull(message = "출발 도시가 존재해야 합니다.")
     @Column(name = "departure_city", nullable = false)
     private String departureCity;
 
+    @NotNull(message = "출발 시간이 존재해야 합니다.")
     @Column(name = "departure_time", nullable = false)
     private LocalDateTime departureDateTime;
 
+    @NotNull(message = "도착 도시가 존재해야 합니다.")
     @Column(name = "arrival_city", nullable = false)
     private String arrivalCity;
 
+    @NotNull(message = "도착 시간이 존재해야 합니다.")
     @Column(name = "arrival_time", nullable = false)
     private LocalDateTime arrivalDateTime;
 
+    @PositiveOrZero(message = "항공편 가격은 0 또는 양수이어야 합니다.")
     @Column(name = "cost", nullable = false)
     private long cost;
 
     @Builder
-    public Flight(@NonNull AirplaneSeat airplaneSeat,
-                  @NotNull String departureCity,
-                  @NonNull LocalDateTime departureDateTime,
-                  @NotNull String arrivalCity,
-                  @NonNull LocalDateTime arrivalDateTime,
+    public Flight(AirplaneSeat airplaneSeat,
+                  String departureCity,
+                  LocalDateTime departureDateTime,
+                  String arrivalCity,
+                  LocalDateTime arrivalDateTime,
                   long cost) {
         this.airplaneSeat = airplaneSeat;
         this.departureCity = departureCity;

--- a/src/main/java/com/grepp/carrierroute/flight/dto/FlightSearchType.java
+++ b/src/main/java/com/grepp/carrierroute/flight/dto/FlightSearchType.java
@@ -9,13 +9,13 @@ import java.util.Arrays;
 public enum FlightSearchType {
     ONEWAY("oneway"){
         @Override
-        public FlightsSearchResponseDto get(FlightService flightService, FlightSearchRequestDto flightSearchRequestDto) {
+        public FlightsSearchResponseDto findFlights(FlightService flightService, FlightSearchRequestDto flightSearchRequestDto) {
             return flightService.findFlightsByOneway(flightSearchRequestDto);
         }
     },
     ROUND("round"){
         @Override
-        public FlightsSearchResponseDto get(FlightService flightService, FlightSearchRequestDto flightSearchRequestDto) {
+        public FlightsSearchResponseDto findFlights(FlightService flightService, FlightSearchRequestDto flightSearchRequestDto) {
             return flightService.findFlightsByRound(flightSearchRequestDto);
         }
     };
@@ -33,5 +33,5 @@ public enum FlightSearchType {
                 .orElse(ONEWAY);
     }
 
-    public abstract FlightsSearchResponseDto get(FlightService flightService, FlightSearchRequestDto flightSearchRequestDto);
+    public abstract FlightsSearchResponseDto findFlights(FlightService flightService, FlightSearchRequestDto flightSearchRequestDto);
 }

--- a/src/main/java/com/grepp/carrierroute/flight/service/FlightService.java
+++ b/src/main/java/com/grepp/carrierroute/flight/service/FlightService.java
@@ -1,5 +1,6 @@
 package com.grepp.carrierroute.flight.service;
 
+import com.grepp.carrierroute.exception.NotFoundException;
 import com.grepp.carrierroute.flight.dto.FlightSearchResponseDto;
 import com.grepp.carrierroute.flight.domain.Flight;
 import com.grepp.carrierroute.flight.dto.FlightSearchRequestDto;
@@ -25,7 +26,8 @@ public class FlightService {
     }
 
     public FlightsSearchResponseDto getFlights(SearchType searchType, FlightSearchRequestDto flightSearchRequestDto) {
-        return searchType.getFlightSearchType().get(this,flightSearchRequestDto);
+        return searchType.getFlightSearchType()
+                .findFlights(this,flightSearchRequestDto);
     }
 
     public FlightsSearchResponseDto findFlightsByOneway(FlightSearchRequestDto flightSearchRequestDto) {
@@ -56,6 +58,11 @@ public class FlightService {
     }
 
     public FlightSearchResponseDto getFlight(Long flightId) {
-        return flightConverter.convertFlightSearchResponseDto(flightRepository.findById(flightId).get());
+        return flightConverter.convertFlightSearchResponseDto(findFlightById(flightId));
+    }
+
+    private Flight findFlightById(Long flightId) {
+        return flightRepository.findById(flightId)
+                .orElseThrow(()->new NotFoundException(Flight.class,flightId));
     }
 }


### PR DESCRIPTION
## 📌 PR 목적 
항공권 관련 Controller의 반환 타입을 ResponseEntity로 적용하고 예외 핸들링 코드를 추가한 것에 대한 코드 리뷰를 받기 위함입니다.

## 👩‍💻 요구 사항과 구현 내용
- FlightController, FlightBookingController의 반환타입 변경
- 항공권 관련 예외 핸들링 코드 추가

## ✅ 피드백 반영사항


## 🤔 PR 포인트 & 궁금한 점
- 항공권 관련 예외 핸들링 코드 구현한 부분에 대한 설명 
    - NotFoundException : findById를 통한 조회 시 Optional 반환 값이 null 일 경우 발생하게 했습니다. (service layer)
    - ConstraintViolationException : 해당 항공편을 갖는 항공사의 취소 가능 여부 반환 컬럼이 false 일 경우  발생하게 했습니다 (service layer)
    - ConstraintViolationException : Entity 클래스에서 Java Bean Validation 시 발생하는 예외 (entity layer)
        - 일단 모든 엔티티에서 컬럼 값에 대한 유효성 검사만 추가하였고 거기서 발생하는 예외를 처리하기 위해 GlobalExceptionHandler에 ConstraintViolationException 처리에 대한 메서드를 추가하였습니다. 

- AlreadBookException(이미 예약된 { })에 대한 것도 통일할 필요성을 느낌 
- 그리고 리팩토링을 엄청나게 해야 됨을 느낌..
    - 먼저 ERD를 다시 수정할 필요가 있음 -> Flight 클래스에 예약, 항공편 조회를 동시에 처리하니 도메인 분리가 안되는 느낌
    - 예약 생성과 예약 삭제의 HTTP Method 에 대한 고민 
        - 이전에 Flight 클래스의 userId를 null로 하냐 안하냐로 예약이 결정되기 때문에 PO가 PATCH method로 통일하자고 하였음.
        - 근데 PATCH로 하자니 내가 짠 uri엔 bookingId가 없고, request엔 POST 메서드를 연상케하는 데이터가 담겨짐.
        - So, 이 http method의 국룰 원칙을 지키기 위해선 리팩토링이 반드시 필요 
    - 항공편 예약 시, 좌석을 배치할거냐 안할거냐!
        - 이 점은 이전 항공편 예약 때 줄리가 리뷰해줬던 내용인데 항공편 예약을 할 때 좌석을 랜덤하게 배정해주는 요구사항을 내가 생각해내서 임의로 넣어줬었음.
        - 이게 큰 골치였던 것 같음. 항공편 조회 시 , 조건에 맞는 Flight 들을 찾고 Flight_id를 response에 담지 못했던 건 좌석 번호는 시스템에서 정해지는건데 클라가 알면 안되지! 해서 담지않음. 
        - 좌석 예약과 항공편 예약의 로직을 분리해야 위와 같은 문제점이 발생하지 않을 것 같음.
        - 단, 항공편 예약에서 좌석 등급에 따른 예약은 불가피 
    
    


## 관련 이슈 
<!-- 예시) Close: #이슈 번호 -->
Closes #73 